### PR TITLE
Fix CellDimXYZ being read as str, not float

### DIFF
--- a/pyprismatic/params.py
+++ b/pyprismatic/params.py
@@ -200,7 +200,7 @@ class Metadata(object):
             print('Could not set cell dimensions from file {}'.format(Fname))
             return
         inf.readline()
-        self.cellDimX, self.cellDimY, self.cellDimZ = inf.readline().split()
+        cellDimX, cellDimY, cellDimZ = [float(i) for i in inf.readline().split()]
         inf.close()
 
     @property


### PR DESCRIPTION
The lines in question were being read as strings, not floats, leading to an error later on in the core.cpp file. This bug was introduced with a commit on the 8th of March, and since then pyprismatic has not been built and uploaded to pip, so that's why noone has noticed, I guess.